### PR TITLE
Add copyzips role to iam stack and param to config stack

### DIFF
--- a/templates/ammos-config.template.yaml
+++ b/templates/ammos-config.template.yaml
@@ -35,6 +35,11 @@ Parameters:
     Description: Will be attached to all created IAM Roles to satisfy security requirements.
     Type: String
     Default: ''
+  IamRoleArn:
+    Description: ARN of a pre-deployed IAM Role with sufficient permissions for the lambda;
+      see the CopyRole resource in the copy-zips template for reference
+    Type: String
+    Default: ''
 Conditions:
   UsingDefaultBucket: !Equals [!Ref QSS3BucketName, "aws-quickstart"]
 Resources:
@@ -64,6 +69,7 @@ Resources:
         StripPrefixAtDestination: 'true'
         PermissionsBoundaryArn: !Ref PermissionsBoundaryArn
         RolePath: !Ref RolePath
+        IamRoleArn: !Ref IamRoleArn
         SourceObjects: !Join
           - ','
           - - configs/ait/ait-config.zip

--- a/templates/ast-iam-roles.template.yaml
+++ b/templates/ast-iam-roles.template.yaml
@@ -313,6 +313,93 @@ Resources:
       ManagedPolicyArns:
         - !Sub 'arn:${AWS::Partition}:iam::aws:policy/AmazonSSMManagedInstanceCore'
         - !Sub 'arn:${AWS::Partition}:iam::aws:policy/CloudWatchAgentServerPolicy'
+  CopyZipsRole:
+    Type: AWS::IAM::Role
+    Properties:
+      Path: !If [RolePathProvided, !Ref RolePath, !Ref AWS::NoValue]
+      PermissionsBoundary:
+        !If [
+          PermissionsBoundaryProvided,
+          !Ref PermissionsBoundaryArn,
+          !Ref AWS::NoValue,
+        ]
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service: lambda.amazonaws.com
+          Action: sts:AssumeRole
+      Policies:
+      - PolicyName: ConfigPolicy
+        PolicyDocument:
+          Version: 2012-10-17
+          Statement:
+          - Sid: Logging
+            Effect: Allow
+            Action:
+              - logs:StartQuery
+              - logs:DeleteLogGroup
+              - logs:CreateLogStream
+              - logs:DisassociateKmsKey
+              - logs:StopQuery
+              - logs:UntagLogGroup
+              - logs:PutResourcePolicy
+              - logs:GetLogGroupFields
+              - logs:GetLogDelivery
+              - logs:TagLogGroup
+              - logs:DeleteRetentionPolicy
+              - logs:PutQueryDefinition
+              - logs:UpdateLogDelivery
+              - logs:FilterLogEvents
+              - logs:PutRetentionPolicy
+              - logs:PutMetricFilter
+              - logs:DescribeQueryDefinitions
+              - logs:PutDestination
+              - logs:GetLogRecord
+              - logs:PutLogEvents
+              - logs:ListLogDeliveries
+              - logs:DescribeExportTasks
+              - logs:DescribeLogStreams
+              - logs:CreateLogGroup
+              - logs:DeleteMetricFilter
+              - logs:CancelExportTask
+              - logs:DescribeMetricFilters
+              - logs:DeleteSubscriptionFilter
+              - logs:DescribeResourcePolicies
+              - logs:DescribeSubscriptionFilters
+              - logs:GetQueryResults
+              - logs:DeleteQueryDefinition
+              - logs:DeleteResourcePolicy
+              - logs:DeleteLogStream
+              - logs:CreateExportTask
+              - logs:DeleteLogDelivery
+              - logs:DescribeLogGroups
+              - logs:CreateLogDelivery
+              - logs:PutDestinationPolicy
+              - logs:GetLogEvents
+              - logs:DescribeQueries
+              - logs:DescribeDestinations
+              - logs:PutSubscriptionFilter
+              - logs:DeleteDestination
+              - logs:TestMetricFilter
+              - logs:ListTagsLogGroup
+            Resource: !Sub arn:${AWS::Partition}:s3:::*
+          - Sid: S3Get
+            Effect: Allow
+            Action:
+            - s3:GetObject
+            Resource: !Sub
+              - arn:${AWS::Partition}:s3:::${S3Bucket}/${QSS3KeyPrefix}*
+              - S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
+          - Sid: S3Put
+            Effect: Allow
+            Action:
+            - s3:PutObject
+            - s3:DeleteObject
+            Resource: !Sub
+            - arn:${AWS::Partition}:s3:::${DestBucket}/*
+            - DestBucket: !Sub ${ProjectName}-config
 
 Outputs:
   DeploymentHelperRoleArn:
@@ -339,8 +426,14 @@ Outputs:
     Description: Name of the EditorServerRole created for AST deployment
     Value: !Ref EditorServerRole
   BastionHostRoleArn:
-    Description: ARN of the BastionHost created for AST deployment
+    Description: ARN of the BastionHostRole created for AST deployment
     Value: !GetAtt BastionHostRole.Arn
   BastionHostRoleName:
-    Description: Name of the BastionHost created for AST deployment
+    Description: Name of the BastionHostRole created for AST deployment
     Value: !Ref BastionHostRole
+  CopyZipsRoleArn:
+    Description: ARN of the CopyZipsRole created for AST deployment
+    Value: !GetAtt CopyZipsRole.Arn
+  CopyZipsRoleName:
+    Description: Name of the CopyZipsRole created for AST deployment
+    Value: !Ref CopyZipsRole


### PR DESCRIPTION
*Description of changes:*
The IAM Resources stack had left off the CopyZips Role (used by the copyzips stack, nested within the config stack). Added this in so that the config stack can also be deployed by those without IAM creation privileges.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
