### PR TITLE
Correct bucket reference in logging template

### DIFF
--- a/templates/ammos-cubs-logging.template.yaml
+++ b/templates/ammos-cubs-logging.template.yaml
@@ -43,6 +43,8 @@ Parameters:
       can include numbers, lowercase letters, uppercase letters, hyphens (-), and
       forward slash (/).
     Type: String
+Conditions:
+  UsingDefaultBucket: !Equals [!Ref QSS3BucketName, 'aws-quickstart']
 Resources:
   ElasticsearchSecurityGroup:
     Type: AWS::EC2::SecurityGroup
@@ -303,7 +305,10 @@ Resources:
           - !Ref PrivateSubnet2ID
           - !Ref PrivateSubnet3ID
       Code:
-        S3Bucket: !Ref QSS3BucketName
+        S3Bucket: !If
+          - UsingDefaultBucket
+          - !Sub '${QSS3BucketName}-${AWS::Region}'
+          - !Ref QSS3BucketName
         S3Key: !Sub "${QSS3KeyPrefix}functions/packages/LoggingProcessorLambda/lambda.zip"
 
 Outputs:


### PR DESCRIPTION
*Description of changes:*
Minor bug fix in logging template for bucket reference when using default quickstart bucket

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
